### PR TITLE
Prevent error caused by passing named arguments to read.cross.tidy

### DIFF
--- a/R/read.cross.tidy.R
+++ b/R/read.cross.tidy.R
@@ -65,9 +65,9 @@ read.cross.tidy <-
     args <- c(args, list(sep = sep, na.strings = na.strings,
                          row.names = 1, header = TRUE, stringsAsFactors = FALSE))
 
-    gen   <- do.call("read.table", c(args, file = genfile))
-    pheno <- do.call("read.table", c(args, file = phefile))
-    map   <- do.call("read.table", c(args, file = mapfile))
+    gen   <- do.call("read.table", c(args, list(file = genfile)))
+    pheno <- do.call("read.table", c(args, list(file = phefile)))
+    map   <- do.call("read.table", c(args, list(file = mapfile)))
 
     # Check individual IDs
     mp <- setdiff(colnames(gen), colnames(pheno))


### PR DESCRIPTION
For example:

``` r
x <- read.cross("tidy", "", genfile=c(geno="hyper_tidy_gen.csv"),
                mapfile="hyper_tidy_map.csv", phefile="hyper_tidy_phe.csv",
                genotypes=c("BB", "BA", "AA"))
```

```
## Error in read.table(sep = ",", na.strings = c("-", "NA"), row.names = 1,  : 
## unused argument (file.geno = "hyper_tidy_gen.csv") 
```

Granted this isn't something many people would encounter. I ran into it while trying to create multiple crosses from a list of input files.
