### PR TITLE
Fixing the duplicate rownames bug by Jesse Weber

### DIFF
--- a/R/mqmscan.R
+++ b/R/mqmscan.R
@@ -379,7 +379,7 @@ mqmscan <- function(cross,cofactors=NULL,pheno.col=1,model=c("additive","dominan
         #Now we handle the off-end and any shifts comming from that (newcmbase)
         #We didn't thow away the old names, and could thus get duplicates
         qtlnew <- qtl
-        rownames(qtlnew) <- NULL
+        rownames(qtlnew) <- paste0("qtlnew_X", 1:nrow(qtl))
         oldnames <- rownames(qtl)
         for(x in 1:n.chr){
             #Do per chromosome


### PR DESCRIPTION
If a marker is a numerical value (e.g. has name 24), but occurs at a position < 24 AND the current chromosome has less then 24 markers, it causes an invalid row.names error (Strange bug).

This assigns a pre-defined name ("qtlnew_X" 1:nrow(qtl)) to the output object before we set back the original marker names. This way, we prevent numerical marker names in the first place, and as such the user is free to use numerical marker names.