### PR TITLE
Fix for permutation issues under linux

### DIFF
--- a/R/mqmpermutation.R
+++ b/R/mqmpermutation.R
@@ -75,7 +75,7 @@ mqmscanfdr <- function(cross, scanfunction=mqmscanall, thresholds=c(1,2,3,4,5,7,
 #
 ######################################################################
 
-mqmpermutation <- function(cross,scanfunction=scanone,pheno.col=1,multicore=TRUE,n.perm=10,batchsize=10,file="MQM_output.txt",n.cluster=1,method=c("permutation","simulation"),cofactors=NULL,plot=FALSE,verbose=FALSE,...)
+mqmpermutation <- function(cross,scanfunction=scanone,pheno.col=1,multicore=TRUE,n.perm=10,file="MQM_output.txt",n.cluster=1,method=c("permutation","simulation"),cofactors=NULL,plot=FALSE,verbose=FALSE,...)
 {
     bootmethod <- 0
 
@@ -91,7 +91,7 @@ mqmpermutation <- function(cross,scanfunction=scanone,pheno.col=1,multicore=TRUE
             cat("------------------------------------------------------------------\n")
             cat("Starting permutation analysis\n")
             cat("Number of permutations:",n.perm,"\n")
-            cat("Batchsize:",batchsize," & n.cluster:",n.cluster,"\n")
+            cat("n.cluster:",n.cluster,"\n")
             cat("------------------------------------------------------------------\n")
             cat("INFO: Received a valid cross file type:",crosstype,".\n")
         }
@@ -106,15 +106,12 @@ mqmpermutation <- function(cross,scanfunction=scanone,pheno.col=1,multicore=TRUE
         cross$pheno[,1] <- cross$pheno[,pheno.col]
         names(cross$pheno)[1] <- names(cross$pheno)[pheno.col]
 
-        if(n.cluster > batchsize){
-            stop("Please have more items in a batch then clusters assigned per batch")
-        }
-
         #Scan the original
         #cross <- fill.geno(cross) # <- this should be done outside of this function
         res0 <- lapply(1, FUN=snowCoreALL,all.data=cross,scanfunction=scanfunction,verbose=verbose,cofactors=cofactors,...)
 
         #Setup bootstraps by generating a list of random numbers to set as seed for each bootstrap
+        batchsize <- length(bootstraps)
         bootstraps <- runif(n.perm)
         batches <- length(bootstraps) %/% batchsize
         last.batch.num <- length(bootstraps) %% batchsize

--- a/R/mqmpermutation.R
+++ b/R/mqmpermutation.R
@@ -111,7 +111,7 @@ mqmpermutation <- function(cross,scanfunction=scanone,pheno.col=1,multicore=TRUE
         res0 <- lapply(1, FUN=snowCoreALL,all.data=cross,scanfunction=scanfunction,verbose=verbose,cofactors=cofactors,...)
 
         #Setup bootstraps by generating a list of random numbers to set as seed for each bootstrap
-        batchsize <- length(bootstraps)
+        batchsize <- n.perm
         bootstraps <- runif(n.perm)
         batches <- length(bootstraps) %/% batchsize
         last.batch.num <- length(bootstraps) %% batchsize

--- a/man/mqmpermutation.Rd
+++ b/man/mqmpermutation.Rd
@@ -14,7 +14,7 @@
 
 \usage{
 mqmpermutation(cross, scanfunction=scanone, pheno.col=1, multicore=TRUE,
-               n.perm=10, batchsize=10, file="MQM_output.txt",
+               n.perm=10, file="MQM_output.txt",
                n.cluster=1, method=c("permutation","simulation"),
                cofactors=NULL, plot=FALSE, verbose=FALSE, \dots)
 }
@@ -30,7 +30,6 @@ Column number in the phenotype matrix which should be used as the phenotype. Thi
         \item{multicore}{ Use multicore (if available)}
         \item{n.perm}{ Number of permutations to perform (DEFAULT=10, should be 1000, or higher,
   for publications) }
-        \item{batchsize}{ Batch size. The entire set is split in jobs. Each job contains b.size number of traits per job }
         \item{file}{ Name of the intermediate output file used }
         \item{n.cluster}{ Number of child processes to split the job into }
         \item{method}{ What kind permutation should occur: permutation or simulation }


### PR DESCRIPTION
Hey Karl,

I got a bug report from Nat Phon-Or that showed an error in the way the random number generation is handled in the cores when using multi-core under Linux systems. The fix is to remove the batching of permutations.

See the attached pull request for the code and documentation changes I made.